### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://codedev.ms/liangzhu/325835a4-7351-4897-8dda-7877fef1f9c9/2fa04b86-0eff-41c5-9bd4-9e088a7e5910/_apis/work/boardbadge/1de7a58d-83ee-4e43-9e21-6d432a637c69)](https://codedev.ms/liangzhu/325835a4-7351-4897-8dda-7877fef1f9c9/_boards/board/t/2fa04b86-0eff-41c5-9bd4-9e088a7e5910/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#6. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.